### PR TITLE
fix logic for fetching sessions and error message fix

### DIFF
--- a/src/middlewares/access.ts
+++ b/src/middlewares/access.ts
@@ -1,6 +1,6 @@
 import { ADMIN_ROLE, MENTOR_ROLE, USER_ROLE } from "../constants/index"
 
-const unauthorized = (res) => res.status(403).send({messsage: 'You are not authorized to perform this action'})
+const unauthorized = (res) => res.status(403).send({message: 'You are not authorized to perform this action'})
 
 export const isAdminRole = (req, res, next) => {
     if (req?.user?.role === ADMIN_ROLE) return next()


### PR DESCRIPTION
This pr redoes the logic for fetching sessions to display on profile page by grouping each category of sessions according the sessionDate. It also fixes a minor typo in error message for unauthorized errors.